### PR TITLE
Fix links to Spring Boot documentation

### DIFF
--- a/spring-boot-actuators.html.md.erb
+++ b/spring-boot-actuators.html.md.erb
@@ -39,7 +39,7 @@ The table below describes the Spring Boot Actuator endpoints supported by Apps M
 <td><code>/health</code></td>
 <td>
 <ul>
-<li><b>Description</b>: Shows health status or detailed health information over a secure connection. <br>Spring Boot Actuator includes the auto-configured health indicators specified in the <a href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html#_auto_configured_healthindicators">Auto-configured HealthIndicators</a> section of the Spring Boot documentation. If you want to write custom health indicators, see the <a href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html#_writing_custom_healthindicators">Writing custom HealthIndicators</a> section of the Spring Boot documentation.</li>
+<li><b>Description</b>: Shows health status or detailed health information over a secure connection. <br>Spring Boot Actuator includes the auto-configured health indicators specified in the <a href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#auto-configured-healthindicators">Auto-configured HealthIndicators</a> section of the Spring Boot documentation. If you want to write custom health indicators, see the <a href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#writing-custom-healthindicators">Writing custom HealthIndicators</a> section of the Spring Boot documentation.</li>
 <li><b>How to use in Apps Man</b>: See <a href="./using-actuators.html#view-app-health">View App Health</a>.</li>
 </ul>
 </td>
@@ -66,7 +66,7 @@ The table below describes the Spring Boot Actuator endpoints supported by Apps M
 <td><code>/trace</code></td>
 <td>
 <ul>
-<li><b>Description</b>: Displays trace information from your app for each of the last 100 HTTP requests. For more information, see the <a href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-tracing.html">Tracing</a> section of the Spring Boot documentation.</li>
+<li><b>Description</b>: Displays trace information from your app for each of the last 100 HTTP requests. For more information, see the <a href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-http-tracing">Tracing</a> section of the Spring Boot documentation.</li>
 <li><b>How to use in Apps Man</b>: See <a href="./using-actuators.html#view-trace">View Request Traces</a>.</li>
 </ul>
 </td>


### PR DESCRIPTION
This should be checked in 2.7 and 2.8 also.