### PR TITLE
Remove "Skip SSL Certificate Verification"

### DIFF
--- a/_router_app_tls_pcf.html.md.erb
+++ b/_router_app_tls_pcf.html.md.erb
@@ -1,7 +1,5 @@
 Verifying app identity using TLS improves resiliency and consistency for app routes.
 
-<p class='note'><strong>Note:</strong> This feature does not work if the <strong>Disable SSL certificate verification for this environment</strong> checkbox is selected in the <strong>Networking</strong> pane of the <%= vars.app_runtime_abbr %> tile.</p>
-
 The **App Containers** pane of the <%= vars.app_runtime_abbr %> tile includes these options under **Gorouter app identity verification**:
 
 * **The Gorouter uses TLS to verify app identity:** Enables the Gorouter to verify app identity using TLS. This is the default option.


### PR DESCRIPTION
## The Change
- Makes `ha_proxy.skip_cert_verify` (Skip SSL Certificate Verification)
unconfigurable and defaulted to `false`
- Removes the form from the tile UI
- Adds migration to prevent upgrading when this feature is configured
`true`
- Removes all documentation referencing to this setting
- Updates Ops Man documentation for case when users want to provide
their own self-signed certificate

[#174811172](https://www.pivotaltracker.com/story/show/174811172)

Co-authored-by: Josh Russett <jrussett@vmware.com>
Co-authored-by: Ryan Hall <hallr@vmware.com>

## Backports
None

## Related PRs
#### Tiles
- pivotal-cf/p-runtime#1826
- pivotal-cf/p-isolation-segment#503
#### Docs
- pivotal-cf/docs-partials#31
- cloudfoundry/docs-cf-admin#194
- pivotal-cf/docs-operating-pas#41
- pivotal-cf/docs-pivotalcf-console#16