### PR TITLE
Add variables to exclude ops settings

### DIFF
--- a/console-roles.html.md.erb
+++ b/console-roles.html.md.erb
@@ -5,7 +5,7 @@ owner: Apps Manager
 
 This topic explains how to manage user roles with Apps Manager.
 
-<% unless vars.book_title == "Pivotal Web Services Documentation" %>
+<% unless vars.disallow_saml_ldap_identity %>
 <!-- This ensures that the note below only appears in the <%= vars.platform_name %> docs, not in the PWS docs.  -->
 
 <p class='note'><strong>Note:</strong> The procedures described here are not compatible with using SAML or LDAP for user identity management. To create and manage user accounts in a SAML- or LDAP-enabled <%= vars.platform_name %> deployment, see <a href='https://docs.pivotal.io/application-service/2-7/operating/external-user-management.html'>Adding Existing SAML or LDAP Users to an <%= vars.platform_name %> Deployment</a>.</p>
@@ -31,7 +31,7 @@ Admins, Org Managers, and Space Managers can assign user roles with Apps Manager
 Foundry Command Line Interface (cf CLI). For more information, see
 [Users and Roles](../cf-cli/getting-started.html#user-roles) in _Getting Started with the cf CLI_.
 
-<% unless vars.book_title == "Pivotal Web Services Documentation" %>
+<% unless vars.disallow_multi_foundation %>
 
 You can manage user roles across multiple foundations. For more information, see
 [Configuring Multi-Foundation Support in Apps Manager](../opsguide/configure-multi-foundation.html).

--- a/manage-apps.html.md.erb
+++ b/manage-apps.html.md.erb
@@ -12,7 +12,7 @@ You can use Apps Manager to manage apps, service instances, service keys, and ro
 
 For information about managing orgs and spaces, see [Managing Orgs and Spaces Using Apps Manager](manage-spaces.html).
 
-<% unless vars.book_title == "Pivotal Web Services Documentation" %>
+<% unless vars.disallow_multi_foundation %>
 <!-- This ensures that the paragraph below only appears in the Pivotal Platform docs, not in the PWS docs.  -->
 
 You can manage apps and service instances across multiple foundations. For more information, see [Configuring Multi-Foundation Support in Apps Manager](../opsguide/configure-multi-foundation.html).

--- a/manage-spaces.html.md.erb
+++ b/manage-spaces.html.md.erb
@@ -15,7 +15,7 @@ You can use Apps Manager to manage orgs and spaces. This includes creating and d
 
 For information about managing apps and service instances, see [Managing Apps and Service Instances Using Apps Manager](manage-apps.html).
 
-<% unless vars.book_title == "Pivotal Web Services Documentation" %>
+<% unless vars.disallow_multi_foundation %>
 <!-- This ensures that the paragraph below only appears in the PCF docs, not in the PWS docs.  -->
 
 You can manage orgs and spaces across multiple foundations. For more information, see [Configuring Multi-Foundation Support in Apps Manager](../opsguide/configure-multi-foundation.html).


### PR DESCRIPTION
- These are currently used for PWS, but need to be used for other web properties as well.
- This change makes the behavior more explicit by not relying on the book title.

Authored-by: Patrick Oyarzun <poyarzun@pivotal.io>

Related to https://github.com/pivotal-cf/docs-book-runpivotal/pull/10