### PR TITLE
Make row name more generic

### DIFF
--- a/_pcf_roles_table.html.md.erb
+++ b/_pcf_roles_table.html.md.erb
@@ -277,7 +277,7 @@
 		<td></td>
 		<td>Yes</td>
 	</tr><tr>
-		<td>Associate routes<sup><strong>5</strong></sup>, instance counts, memory allocation, and disk limit of apps</td>
+		<td>Associate routes<sup><strong>5</strong></sup>, modify resource allocation of apps</td>
 		<td>Yes</td>
 		<td></td>
 		<td></td>

--- a/_pcf_suspended_roles_table.html.md.erb
+++ b/_pcf_suspended_roles_table.html.md.erb
@@ -214,7 +214,7 @@
 		<td></td>
 		<td></td>
 	</tr><tr>
-		<td>Associate routes<sup>&dagger;</sup>, instance counts, memory allocation, and disk limit of apps</td>
+		<td>Associate routes<sup>&dagger;</sup>, modify resource allocation of apps</td>
 		<td>Yes</td>
 		<td></td>
 		<td></td>


### PR DESCRIPTION
With the addition of log rate limiting we decided to no longer enumerate all of the resource types that can be allocated.

[#183065417](https://www.pivotaltracker.com/story/show/183065417)
